### PR TITLE
Changes to header links and index

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -15,23 +15,13 @@
     <header>
       <nav id="main-nav">
         <ul>
-          <li>
-            <a href="{{ '/' | relative_url }}#home"
-              ><img
-                src="{{ '/assets/images/home.svg' | relative_url }}"
-                alt="Home"
-            /></a>
-          </li>
-          <li><a href="{{ '/' | relative_url }}#about">About</a></li>
-          <li><a href="{{ '/' | relative_url }}#dates">Dates</a></li>
-          <li><a href="{{ '/' | relative_url }}#program">Program</a></li>
-          <li><a href="{{ '/' | relative_url }}#papers">Papers</a></li>
-          <li>
-            <a href="{{ '/hci-special-issue' | relative_url }}"
-              >Call for Articles (new)</a
-            >
-          </li>
-          <li><a href="{{ '/' | relative_url }}#organizers">Organizers</a></li>
+        <li><a href="{{ '/' | relative_url }}#home"><img src="{{ '/assets/images/home.svg' | relative_url }}" alt="Home"></a></li>
+        <li><a href="{{ '/' | relative_url }}#news">News</a></li>
+        <li><a href="{{ '/' | relative_url }}#about">About</a></li>
+        <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li>
+        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP (NEW!)</a></li>
+        <li><a href="{{ '/' | relative_url }}#organizers">2025 Organizers</a></li>
+        <li><a href="{{ '/' | relative_url }}#archive-dates-program">Archive: 2025 Workshop Dates and Program</a></li>
         </ul>
       </nav>
     </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,10 +15,10 @@
         <li><a href="{{ '/' | relative_url }}#home"><img src="{{ '/assets/images/home.svg' | relative_url }}" alt="Home"></a></li>
         <li><a href="{{ '/' | relative_url }}#news">News</a></li>
         <li><a href="{{ '/' | relative_url }}#about">About</a></li>
-        <li><a href="{{ '/' | relative_url }}#papers">Papers</a></li>
+        <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li>
         <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP (NEW!)</a></li>
-        <li><a href="{{ '/' | relative_url }}#organizers">Organizers</a></li>
-        <li><a href="{{ '/' | relative_url }}#archival">Archival: Dates and Program</a></li>
+        <li><a href="{{ '/' | relative_url }}#organizers">2025 Organizers</a></li>
+        <li><a href="{{ '/' | relative_url }}#archive-dates-program">Archive: 2025 Workshop Dates and Program</a></li>
       </ul>
     </nav>
   </header>

--- a/index.md
+++ b/index.md
@@ -14,6 +14,12 @@ Saturday, April 26, 2025 — 9AM-5:50PM JST — Yokohama, Japan
     <img src="{{ '/assets/images/banner2.png' | relative_url }}" alt="Workshop Banner" class="hero-image" />
 </div>
 
+## News {#news}
+
+- *2025 Workshop Synthesis*: Coming soon!  
+- *2026 Special Issue CFP*: <a href="{{ '/hci-special-issue' | relative_url }}">2026 Human Computer Interaction Special Issue CFP (NEW!)</a>
+
+
 ## About {#about}
 
 GenAI radically widens the scope and capability of automation for work, learning, and creativity. While impactful, it also changes workflows, raising questions about its effects on cognition, including critical thinking and learning. Yet GenAI also offers opportunities for designing “tools for thought” that protect and augment cognition. Such systems provoke critical thinking, provide personalized tutoring, or enable novel ways of sensemaking, among other approaches.  
@@ -22,14 +28,60 @@ How does GenAI change workflows and human cognition? What are opportunities and 
 
 Feel free to [join our Discord server](https://discord.gg/WtEzx43ZmD), where you can ask questions, or discuss the topics of this workshop.
 
-## Key Dates {#dates}
 
-- **Deadline for submissions:** <del>Thursday, February 13 2025</del> Thursday, February 20 2025 AoE (extended)
-- **Notifications of acceptance:** <del>Friday, February 28 2025</del> Monday, March 10, 2025 AoE (extended)
-- **Camera-ready:** Friday, April 11 2025 AoE
-- **Day of Workshop:** Saturday, April 26 2025 JST
+## Papers {#papers}
 
-## Workshop Program {#program}
+All accepted papers for this workshop are available in our [GitHub repository](https://github.com/ai-tools-for-thought/workshop/tree/main/documents). You can browse and download the PDF files directly from there.
+
+| Author | Title |
+| --- | --- |
+| Dinesh Ayyappan and David A. Joyner | [Understanding, Protecting, and Augmenting Human Cognition with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Ayyappan%20and%20Joyner%20-%20CHI_ToolsForThought_PositionPaper_CameraReady.pdf) | 
+| Jessica Y. Bo et al. | [Who's the Leader? Analyzing Novice Workflows in LLM-Assisted Debugging of Machine Learning Code](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Bo%20et%20al%20-%20whos_the_leader_tools_for_thought_CHI25_.pdf)|
+| Chance Casteñeda and Jessica Mindel et al. | [Supporting AI-Augmented Meta-Decision Making with InDecision](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Castaneda%20and%20Mindel%20et%20al%20-%20CHI%20T4T%20-%20Supporting%20AI-Augmented%20Meta-Decision%20Making%20with%20InDecision.pdf)  |
+| Manni Cheung | [From Answer Machines to Ignorant Co-Learners: Designing AI to Augment Rather than Replace Human Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Cheung%20-%20From_Answering_Machines_to_Ignorant_Co_Learners__Final_.pdf) |
+| Peter Dalsgaard | [Generative AI as a Tool for Designerly Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Dalsgaard%20-%202025%20-%20Generative_AI_as_a_Tool_for_Designerly_Thinking.pdf) |
+| Yue (Chris) Fu and Alexis Hiniker | [Supporting Students’ Reading and Cognition with AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Fu%20and%20Hiniker%20-%2025_CHI_Workshop__Students__Reading_and_Cognition%20-%20%20to%20Committee.pdf) |
+| Frederic Gmeiner et al. | [Designing Metacognitive Support Interactions to Augment People’s Thinking in Complex (Co-)Creative Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Gmeiner%20et%20al%20-%20Gmeiner_DesigningMetacognitiveSupport_ToolsForThought_CHI25_CameraReady.pdf) |
+| Joshua Holstein et al. | [From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Holstein%20et%20al%20-%20CHI25_Tools_for_Thought_Consumption%20to%20Engagement%20Framework.pdf) |
+| Janet G. Johnson and Steven R. Rick | [The Promise and Peril of Collaboration: Fostering Appropriate Reliance When Problem-Solving with GenAI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Johnson%20and%20Rick%20-%20Toolsforthought_CHI25_CollaborativeGenAI.pdf) |
+| Anjali Khurana and Parmit K. Chilana | [Designing Semi-Automated Copilots: Balancing User Control and Guidance for Effective Human-Agent Collaboration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Khurana%20and%20Chilana%20-%20CHI2025_Workshop_CameraReady.pdf) |
+| Eunhye Kim et al. | [Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Kim%20et%20al%20-%20CHI25_Workshop_BeyondTools_Kim_CameraReady.pdf.pdf) |
+| Markus Langer | [Why Should we Invest Epistemic Labor in a World of Generative AI?](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Langer%20-%20CHI25_Tools_for_Thought_Workshop.pdf) |
+| Joanne Leong | [Designing Transformative Lenses to Aid Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Leong%20-%20JoanneLeong-TransformativeLenses-CameraReady.pdf) |
+| Can Liu and Wengxi Li | [Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20-%20Liu_Li_TFTWorkshop.pdf) |
+| Xingyu Bruce Liu et al. | [Interacting with Thoughtful AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20et%20al%20-%20CHI_2025_Workshop_Thought_Position_Paper.pdf) |
+| Bryan Min and Haijun Xia | [Feedforward in Generative AI: Opportunities for a Design Space](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Min%20and%20Xia%20-%20CHI25_Workshop___Feedforward_in_GenAI.pdf) |
+| Anirban Mukhopadhyay and Kurt Luther | [Tailoring Generative AI to Augment Creative Leadership in Capture-The-Flag Development](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Mukhopadhyay%20and%20Luther%20-%20Anirban_Tools_For_Thought_Workshop_Paper.pdf) |
+| Syeda Masooma Naqvi et al. | [Computational Reification of Creativity: How Generative AI Reshapes Creative Cognition](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Naqvi%20et%20al%20-%20CHI2025_Workshop_Tools4Thought.pdf) |
+| Sachita Nishal et al. | [Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Nishal%20et%20al%20-%20Tools%20for%20Thought%20-%20Camera-Ready.pdf) |
+| Kris Pilcher and Esen K. Tütüncü | [Purposefully Induced Psychosis (PIP): Embracing Hallucination as Imagination in Large Language Models](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Pilcher%20and%20Tutuncu%20-%20PIP_CHI25_TfTSubmission.pdf) |
+| James Prather and Brent N. Reeves | [Pedagogy for critical engagement with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Prather%20and%20Reeves%20-%20CHI_2025___Workshop_for_Tools_on_Thought.pdf) |
+| Chris Quintana and Rebecca M. Quintana | [Students’ Experiences Using Generative AI Within Learning Experience Design Workflows](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Quintana%20and%20Quintana-CHI%202025_Workshop-FINAL.pdf) |
+| Kathrin Schnizer and Sven Mayer | [User-Centered AI for Data Exploration – Rethinking GenAI’s Role in Visualization](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Schnizer%20and%20Mayer%20-%20schnizer2025usr.pdf) |
+| Anjali Singh et al. | [Protecting Human Cognition in the Age of AI](https://github.com/ai-tools-for-thought/workshop/tree/main/documents) |
+| Alexa Siu and Raymond Fok | [Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Singh%20et%20al%20-%20Tools_for_Thought_Workshop_paper.pdf) |
+| Petr Slovak | [Tools for (Changing) Thought: Scaffolding Cognitive Skills Development within Mental Health Contexts](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Slovak%20-%20Tools4Thought_workshop-cameraReady.pdf) |
+| Sangho Suh | [The Next Leap Forward in Human Intelligence: Expanding & Exploring Complex Spaces of Thought](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Suh%20-%20CHI25%20Tools%20for%20Thought%20Workshop%20-%20SanghoSuh.pdf) |
+| Nick von Felten | [Beyond Isolation: Towards an Interactionist Perspective on Human Bias and AI Bias](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Von%20Felten%20-%20Beyond_Isolation_Tools_For_Thought_CHI2025_Workshop.pdf) |
+| Sitong Wang and Lydia B. Chilton | [Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Wang%20and%20Chilton%20-%20Schemex.pdf) |
+| Haijun Xia | [Generative, Malleable, and Personal Information Environment](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Xia%20-%20Generative%2C%20Malleable%2C%20and%20Personal%20User%20Interfaces.%20Haijun%20Xia.%20UCSD.pdf) |
+| Yaqing Yang et al. | [From Overload to Insight: Scaffolding Creative Ideation through Structuring Inspiration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yang%20et%20al%20-%20Scaffolding%20Creative%20Ideation.pdf) |
+| Ryan Yen et al. | [Something In Between Formal Spec and Informal Representation](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yen%20et%20al%20-%20Semi_Formal_Programming__CHI25_T4T_Workshop_%20(3).pdf) |
+| Zelun Tony Zhang and Leon Reicherts | [Augmenting Human Cognition With Generative AI: Lessons From AI-Assisted Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zhang%20and%20Reicherts%20-%20T4T_Workshop_Paper_camera_ready.pdf) |
+| Tim Zindulka et al. | [Prompting by Doing: How Direct Manipulation can Protect and Augment Writers' Thoughts in AI Tools](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zindulka%20et%20al%20-%20CHI25___Tools_for_Thoughts__Prompting_by_Doing.pdf) |
+
+## Organizers {#organizers}
+
+## Archive {#archive-dates-program}
+
+### 2025 Workshop Key Dates
+
+- **Deadline for submissions:** <del>Thursday, February 20 2025 AoE (extended)</del>
+- **Notifications of acceptance:** <del>Friday, February 28 2025</del> Monday, March 10, 2025 AoE (extended)</del>
+- **Camera-ready:** <del>Friday, April 11 2025 AoE</del>
+- **Day of Workshop:** <del>Saturday, April 26 2025 JST</del>
+
+### 2025 Workshop Program
 
 **9:00–9:30 (30min)**  
 Welcome and introduction
@@ -80,45 +132,3 @@ Next steps and closing
 
 Note that the workshop will be **in-person only** to facilitate in-depth discussion among all participants, and to avoid challenges in ensuring equitable opportunities for participation between in-person and remote attendees. While we acknowledge that this decision would unfortunately exclude those who cannot travel to attend in person, we believe that this trade-off would result in a superior experience for those who do attend, and is better aligned with the primary community-building aim of the workshop. Alongside synchronous in-person engagement, we will use [our Discord server](https://discord.gg/WtEzx43ZmD), which anyone is free to join, for asynchronous discussions before, during, and after the workshop.
 
-## Papers {#papers}
-
-All accepted papers for this workshop are available in our [GitHub repository](https://github.com/ai-tools-for-thought/workshop/tree/main/documents). You can browse and download the PDF files directly from there.
-
-| Author | Title |
-| --- | --- |
-| Dinesh Ayyappan and David A. Joyner | [Understanding, Protecting, and Augmenting Human Cognition with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Ayyappan%20and%20Joyner%20-%20CHI_ToolsForThought_PositionPaper_CameraReady.pdf) | 
-| Jessica Y. Bo et al. | [Who's the Leader? Analyzing Novice Workflows in LLM-Assisted Debugging of Machine Learning Code](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Bo%20et%20al%20-%20whos_the_leader_tools_for_thought_CHI25_.pdf)|
-| Chance Casteñeda and Jessica Mindel et al. | [Supporting AI-Augmented Meta-Decision Making with InDecision](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Castaneda%20and%20Mindel%20et%20al%20-%20CHI%20T4T%20-%20Supporting%20AI-Augmented%20Meta-Decision%20Making%20with%20InDecision.pdf)  |
-| Manni Cheung | [From Answer Machines to Ignorant Co-Learners: Designing AI to Augment Rather than Replace Human Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Cheung%20-%20From_Answering_Machines_to_Ignorant_Co_Learners__Final_.pdf) |
-| Peter Dalsgaard | [Generative AI as a Tool for Designerly Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Dalsgaard%20-%202025%20-%20Generative_AI_as_a_Tool_for_Designerly_Thinking.pdf) |
-| Yue (Chris) Fu and Alexis Hiniker | [Supporting Students’ Reading and Cognition with AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Fu%20and%20Hiniker%20-%2025_CHI_Workshop__Students__Reading_and_Cognition%20-%20%20to%20Committee.pdf) |
-| Frederic Gmeiner et al. | [Designing Metacognitive Support Interactions to Augment People’s Thinking in Complex (Co-)Creative Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Gmeiner%20et%20al%20-%20Gmeiner_DesigningMetacognitiveSupport_ToolsForThought_CHI25_CameraReady.pdf) |
-| Joshua Holstein et al. | [From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Holstein%20et%20al%20-%20CHI25_Tools_for_Thought_Consumption%20to%20Engagement%20Framework.pdf) |
-| Janet G. Johnson and Steven R. Rick | [The Promise and Peril of Collaboration: Fostering Appropriate Reliance When Problem-Solving with GenAI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Johnson%20and%20Rick%20-%20Toolsforthought_CHI25_CollaborativeGenAI.pdf) |
-| Anjali Khurana and Parmit K. Chilana | [Designing Semi-Automated Copilots: Balancing User Control and Guidance for Effective Human-Agent Collaboration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Khurana%20and%20Chilana%20-%20CHI2025_Workshop_CameraReady.pdf) |
-| Eunhye Kim et al. | [Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Kim%20et%20al%20-%20CHI25_Workshop_BeyondTools_Kim_CameraReady.pdf.pdf) |
-| Markus Langer | [Why Should we Invest Epistemic Labor in a World of Generative AI?](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Langer%20-%20CHI25_Tools_for_Thought_Workshop.pdf) |
-| Joanne Leong | [Designing Transformative Lenses to Aid Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Leong%20-%20JoanneLeong-TransformativeLenses-CameraReady.pdf) |
-| Can Liu and Wengxi Li | [Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20-%20Liu_Li_TFTWorkshop.pdf) |
-| Xingyu Bruce Liu et al. | [Interacting with Thoughtful AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20et%20al%20-%20CHI_2025_Workshop_Thought_Position_Paper.pdf) |
-| Bryan Min and Haijun Xia | [Feedforward in Generative AI: Opportunities for a Design Space](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Min%20and%20Xia%20-%20CHI25_Workshop___Feedforward_in_GenAI.pdf) |
-| Anirban Mukhopadhyay and Kurt Luther | [Tailoring Generative AI to Augment Creative Leadership in Capture-The-Flag Development](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Mukhopadhyay%20and%20Luther%20-%20Anirban_Tools_For_Thought_Workshop_Paper.pdf) |
-| Syeda Masooma Naqvi et al. | [Computational Reification of Creativity: How Generative AI Reshapes Creative Cognition](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Naqvi%20et%20al%20-%20CHI2025_Workshop_Tools4Thought.pdf) |
-| Sachita Nishal et al. | [Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Nishal%20et%20al%20-%20Tools%20for%20Thought%20-%20Camera-Ready.pdf) |
-| Kris Pilcher and Esen K. Tütüncü | [Purposefully Induced Psychosis (PIP): Embracing Hallucination as Imagination in Large Language Models](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Pilcher%20and%20Tutuncu%20-%20PIP_CHI25_TfTSubmission.pdf) |
-| James Prather and Brent N. Reeves | [Pedagogy for critical engagement with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Prather%20and%20Reeves%20-%20CHI_2025___Workshop_for_Tools_on_Thought.pdf) |
-| Chris Quintana and Rebecca M. Quintana | [Students’ Experiences Using Generative AI Within Learning Experience Design Workflows](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Quintana%20and%20Quintana-CHI%202025_Workshop-FINAL.pdf) |
-| Kathrin Schnizer and Sven Mayer | [User-Centered AI for Data Exploration – Rethinking GenAI’s Role in Visualization](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Schnizer%20and%20Mayer%20-%20schnizer2025usr.pdf) |
-| Anjali Singh et al. | [Protecting Human Cognition in the Age of AI](https://github.com/ai-tools-for-thought/workshop/tree/main/documents) |
-| Alexa Siu and Raymond Fok | [Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Singh%20et%20al%20-%20Tools_for_Thought_Workshop_paper.pdf) |
-| Petr Slovak | [Tools for (Changing) Thought: Scaffolding Cognitive Skills Development within Mental Health Contexts](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Slovak%20-%20Tools4Thought_workshop-cameraReady.pdf) |
-| Sangho Suh | [The Next Leap Forward in Human Intelligence: Expanding & Exploring Complex Spaces of Thought](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Suh%20-%20CHI25%20Tools%20for%20Thought%20Workshop%20-%20SanghoSuh.pdf) |
-| Nick von Felten | [Beyond Isolation: Towards an Interactionist Perspective on Human Bias and AI Bias](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Von%20Felten%20-%20Beyond_Isolation_Tools_For_Thought_CHI2025_Workshop.pdf) |
-| Sitong Wang and Lydia B. Chilton | [Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Wang%20and%20Chilton%20-%20Schemex.pdf) |
-| Haijun Xia | [Generative, Malleable, and Personal Information Environment](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Xia%20-%20Generative%2C%20Malleable%2C%20and%20Personal%20User%20Interfaces.%20Haijun%20Xia.%20UCSD.pdf) |
-| Yaqing Yang et al. | [From Overload to Insight: Scaffolding Creative Ideation through Structuring Inspiration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yang%20et%20al%20-%20Scaffolding%20Creative%20Ideation.pdf) |
-| Ryan Yen et al. | [Something In Between Formal Spec and Informal Representation](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yen%20et%20al%20-%20Semi_Formal_Programming__CHI25_T4T_Workshop_%20(3).pdf) |
-| Zelun Tony Zhang and Leon Reicherts | [Augmenting Human Cognition With Generative AI: Lessons From AI-Assisted Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zhang%20and%20Reicherts%20-%20T4T_Workshop_Paper_camera_ready.pdf) |
-| Tim Zindulka et al. | [Prompting by Doing: How Direct Manipulation can Protect and Augment Writers' Thoughts in AI Tools](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zindulka%20et%20al%20-%20CHI25___Tools_for_Thoughts__Prompting_by_Doing.pdf) |
-
-## Organizers {#organizers}


### PR DESCRIPTION
Updating the main index page to 
* On the index page, add a News list with (a) a coming soon note for the synthesis paper that Lev has written and (b) a link to the CFP
* In the header for all pages (in article and default), change the existing dates and program links to sections on index to a new Archive section (since they are no longer relevant)
* On the index page, put the 2025 dates and program at the bottom in an Archive section