### PR TITLE
add CfP information and move 2025 information to an individual page

### DIFF
--- a/2025.md
+++ b/2025.md
@@ -1,0 +1,109 @@
+---
+layout: article
+title: "CHI 2025 Workshop on Tools for Thought"
+---
+<h1>Archive: CHI 2025 Workshop on Tools for Thought
+<br></h1>
+
+## CHI 2025 Workshop Papers {#papers}
+
+All accepted papers for this workshop are available in our [GitHub repository](https://github.com/ai-tools-for-thought/workshop/tree/main/documents). You can browse and download the PDF files directly from there.
+
+| Author | Title |
+| --- | --- |
+| Dinesh Ayyappan and David A. Joyner | [Understanding, Protecting, and Augmenting Human Cognition with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Ayyappan%20and%20Joyner%20-%20CHI_ToolsForThought_PositionPaper_CameraReady.pdf) | 
+| Jessica Y. Bo et al. | [Who's the Leader? Analyzing Novice Workflows in LLM-Assisted Debugging of Machine Learning Code](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Bo%20et%20al%20-%20whos_the_leader_tools_for_thought_CHI25_.pdf)|
+| Chance Casteñeda and Jessica Mindel et al. | [Supporting AI-Augmented Meta-Decision Making with InDecision](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Castaneda%20and%20Mindel%20et%20al%20-%20CHI%20T4T%20-%20Supporting%20AI-Augmented%20Meta-Decision%20Making%20with%20InDecision.pdf)  |
+| Manni Cheung | [From Answer Machines to Ignorant Co-Learners: Designing AI to Augment Rather than Replace Human Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Cheung%20-%20From_Answering_Machines_to_Ignorant_Co_Learners__Final_.pdf) |
+| Peter Dalsgaard | [Generative AI as a Tool for Designerly Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Dalsgaard%20-%202025%20-%20Generative_AI_as_a_Tool_for_Designerly_Thinking.pdf) |
+| Yue (Chris) Fu and Alexis Hiniker | [Supporting Students' Reading and Cognition with AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Fu%20and%20Hiniker%20-%2025_CHI_Workshop__Students__Reading_and_Cognition%20-%20%20to%20Committee.pdf) |
+| Frederic Gmeiner et al. | [Designing Metacognitive Support Interactions to Augment People's Thinking in Complex (Co-)Creative Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Gmeiner%20et%20al%20-%20Gmeiner_DesigningMetacognitiveSupport_ToolsForThought_CHI25_CameraReady.pdf) |
+| Joshua Holstein et al. | [From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Holstein%20et%20al%20-%20CHI25_Tools_for_Thought_Consumption%20to%20Engagement%20Framework.pdf) |
+| Janet G. Johnson and Steven R. Rick | [The Promise and Peril of Collaboration: Fostering Appropriate Reliance When Problem-Solving with GenAI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Johnson%20and%20Rick%20-%20Toolsforthought_CHI25_CollaborativeGenAI.pdf) |
+| Anjali Khurana and Parmit K. Chilana | [Designing Semi-Automated Copilots: Balancing User Control and Guidance for Effective Human-Agent Collaboration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Khurana%20and%20Chilana%20-%20CHI2025_Workshop_CameraReady.pdf) |
+| Eunhye Kim et al. | [Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Kim%20et%20al%20-%20CHI25_Workshop_BeyondTools_Kim_CameraReady.pdf.pdf) |
+| Markus Langer | [Why Should we Invest Epistemic Labor in a World of Generative AI?](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Langer%20-%20CHI25_Tools_for_Thought_Workshop.pdf) |
+| Joanne Leong | [Designing Transformative Lenses to Aid Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Leong%20-%20JoanneLeong-TransformativeLenses-CameraReady.pdf) |
+| Can Liu and Wengxi Li | [Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20-%20Liu_Li_TFTWorkshop.pdf) |
+| Xingyu Bruce Liu et al. | [Interacting with Thoughtful AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20et%20al%20-%20CHI_2025_Workshop_Thought_Position_Paper.pdf) |
+| Bryan Min and Haijun Xia | [Feedforward in Generative AI: Opportunities for a Design Space](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Min%20and%20Xia%20-%20CHI25_Workshop___Feedforward_in_GenAI.pdf) |
+| Anirban Mukhopadhyay and Kurt Luther | [Tailoring Generative AI to Augment Creative Leadership in Capture-The-Flag Development](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Mukhopadhyay%20and%20Luther%20-%20Anirban_Tools_For_Thought_Workshop_Paper.pdf) |
+| Syeda Masooma Naqvi et al. | [Computational Reification of Creativity: How Generative AI Reshapes Creative Cognition](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Naqvi%20et%20al%20-%20CHI2025_Workshop_Tools4Thought.pdf) |
+| Sachita Nishal et al. | [Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Nishal%20et%20al%20-%20Tools%20for%20Thought%20-%20Camera-Ready.pdf) |
+| Kris Pilcher and Esen K. Tütüncü | [Purposefully Induced Psychosis (PIP): Embracing Hallucination as Imagination in Large Language Models](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Pilcher%20and%20Tutuncu%20-%20PIP_CHI25_TfTSubmission.pdf) |
+| James Prather and Brent N. Reeves | [Pedagogy for critical engagement with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Prather%20and%20Reeves%20-%20CHI_2025___Workshop_for_Tools_on_Thought.pdf) |
+| Chris Quintana and Rebecca M. Quintana | [Students' Experiences Using Generative AI Within Learning Experience Design Workflows](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Quintana%20and%20Quintana-CHI%202025_Workshop-FINAL.pdf) |
+| Kathrin Schnizer and Sven Mayer | [User-Centered AI for Data Exploration – Rethinking GenAI's Role in Visualization](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Schnizer%20and%20Mayer%20-%20schnizer2025usr.pdf) |
+| Anjali Singh et al. | [Protecting Human Cognition in the Age of AI](https://github.com/ai-tools-for-thought/workshop/tree/main/documents) |
+| Alexa Siu and Raymond Fok | [Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Singh%20et%20al%20-%20Tools_for_Thought_Workshop_paper.pdf) |
+| Petr Slovak | [Tools for (Changing) Thought: Scaffolding Cognitive Skills Development within Mental Health Contexts](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Slovak%20-%20Tools4Thought_workshop-cameraReady.pdf) |
+| Sangho Suh | [The Next Leap Forward in Human Intelligence: Expanding & Exploring Complex Spaces of Thought](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Suh%20-%20CHI25%20Tools%20for%20Thought%20Workshop%20-%20SanghoSuh.pdf) |
+| Nick von Felten | [Beyond Isolation: Towards an Interactionist Perspective on Human Bias and AI Bias](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Von%20Felten%20-%20Beyond_Isolation_Tools_For_Thought_CHI2025_Workshop.pdf) |
+| Sitong Wang and Lydia B. Chilton | [Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Wang%20and%20Chilton%20-%20Schemex.pdf) |
+| Haijun Xia | [Generative, Malleable, and Personal Information Environment](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Xia%20-%20Generative%2C%20Malleable%2C%20and%20Personal%20User%20Interfaces.%20Haijun%20Xia.%20UCSD.pdf) |
+| Yaqing Yang et al. | [From Overload to Insight: Scaffolding Creative Ideation through Structuring Inspiration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yang%20et%20al%20-%20Scaffolding%20Creative%20Ideation.pdf) |
+| Ryan Yen et al. | [Something In Between Formal Spec and Informal Representation](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yen%20et%20al%20-%20Semi_Formal_Programming__CHI25_T4T_Workshop_%20(3).pdf) |
+| Zelun Tony Zhang and Leon Reicherts | [Augmenting Human Cognition With Generative AI: Lessons From AI-Assisted Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zhang%20and%20Reicherts%20-%20T4T_Workshop_Paper_camera_ready.pdf) |
+| Tim Zindulka et al. | [Prompting by Doing: How Direct Manipulation can Protect and Augment Writers' Thoughts in AI Tools](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zindulka%20et%20al%20-%20CHI25___Tools_for_Thoughts__Prompting_by_Doing.pdf) |
+
+### CHI 2025 Workshop Key Dates
+
+- **Deadline for submissions:** <del>Thursday, February 20 2025 AoE (extended)</del>
+- **Notifications of acceptance:** <del>Friday, February 28 2025</del> Monday, March 10, 2025 AoE (extended)</del>
+- **Camera-ready:** <del>Friday, April 11 2025 AoE</del>
+- **Day of Workshop:** <del>Saturday, April 26 2025 JST</del>
+
+### CHI 2025 Workshop Program
+
+**9:00–9:30 (30min)**  
+Welcome and introduction
+
+**9:30–10:45 (75min)**  
+The impact of GenAI on cognition and workflows (lightning talks + panel discussion)  
+- *Generative AI as a Tool for Designerly Thinking (Peter Dalsgaard)*  
+- *Protecting Human Cognition in the Age of AI (Anjali Singh)*
+- *From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks (Joshua Holstein)*  
+- *Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making (Eunhye Kim)*
+- *Supporting Students’ Reading and Cognition with AI (Chris Fu)*
+
+**10:45–11:10 (25min)**   
+Coffee break (and optional informal demos)  
+
+**11:10–12:40 (90min)**  
+Designing for cognitive protection and augmentation: User research (lightning talks + panel discussion)
+- *Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work (Alexa Siu)*  
+- *Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism (Sachita Nishal)*
+- *User-Centered AI for Data Exploration – Rethinking GenAI’s Role in Visualization (Kathrin Schnizer)*
+
+Designing for cognitive protection and augmentation: Systems (lightning talks + panel discussion)
+- *Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement (Sitong Wang)*  
+- *Supporting AI-Augmented Meta-Decision Making with InDecision (Jessica Mindel)*  
+- *From Overload to Insight: Structuring Creative Ideation through Structuring Inspiration (Yaqing Yang)*
+
+**12:40–14:10 (90min)**  
+Lunch  
+
+**14:10–15:25 (75min)**  
+Designing for cognitive protection and augmentation: Design approaches (lightning talks + panel discussion)
+- *Prompting by Doing: How Direct Manipulation can Protect and Augment Writers’ Thoughts in AI Tools (Tim Zindulka)*  
+- *Feedforward in Generative AI: Opportunities for a Design Space (Bryan Min)*  
+- *Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content (Can Liu)*  
+- *Interacting with Thoughtful AI (Xingyu Bruce Liu)*  
+- *Something In Between Formal Spec and Informal Representation (Ryan Yen)*
+
+**15:40–16:05 (25min)**  
+Coffee break (and optional informal demos)  
+
+**16:05–17:20 (75min)**    
+Co-ideation session: Mapping research and design opportunities
+
+**17:20–17:50 (30min)**    
+Next steps and closing
+
+<br>
+
+Note that the workshop will be **in-person only** to facilitate in-depth discussion among all participants, and to avoid challenges in ensuring equitable opportunities for participation between in-person and remote attendees. While we acknowledge that this decision would unfortunately exclude those who cannot travel to attend in person, we believe that this trade-off would result in a superior experience for those who do attend, and is better aligned with the primary community-building aim of the workshop. Alongside synchronous in-person engagement, we will use [our Discord server](https://discord.gg/WtEzx43ZmD), which anyone is free to join, for asynchronous discussions before, during, and after the workshop.
+
+## CHI2025 Organizers
+
+{% include organizers.html %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -18,10 +18,12 @@
         <li><a href="{{ '/' | relative_url }}#home"><img src="{{ '/assets/images/home.svg' | relative_url }}" alt="Home"></a></li>
         <li><a href="{{ '/' | relative_url }}#news">News</a></li>
         <li><a href="{{ '/' | relative_url }}#about">About</a></li>
-        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
         <!-- <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li> -->
-        <li><a href="{{ '/' | relative_url }}#organizers">2026 Organizers</a></li>
-        <li><a href="{{ '/' | relative_url }}#archive-dates-program">Archive: CHI 2025 Workshop</a></li>
+        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
+        <li><a href="{{ '/' | relative_url }}#themes">Themes</a></li>
+        <li><a href="{{ '/' | relative_url }}#submission">Submission</a></li>
+        <li><a href="{{ '/' | relative_url }}#organizers"> Organizers</a></li>
+        <li><a href="{{ '/2025' | relative_url }}">Archive: CHI 2025 Workshop</a></li>
         </ul>
       </nav>
     </header>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -19,9 +19,9 @@
         <li><a href="{{ '/' | relative_url }}#news">News</a></li>
         <li><a href="{{ '/' | relative_url }}#about">About</a></li>
         <!-- <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li> -->
-        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
         <li><a href="{{ '/' | relative_url }}#themes">Themes</a></li>
-        <li><a href="{{ '/' | relative_url }}#submission">Submission</a></li>
+        <li><a href="{{ '/' | relative_url }}#submission">Workshop Submission</a></li>
+        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
         <li><a href="{{ '/' | relative_url }}#organizers"> Organizers</a></li>
         <li><a href="{{ '/2025' | relative_url }}">Archive: CHI 2025 Workshop</a></li>
         </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,9 +16,11 @@
         <li><a href="{{ '/' | relative_url }}#news">News</a></li>
         <li><a href="{{ '/' | relative_url }}#about">About</a></li>
         <!-- <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li> -->
-        <!-- <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP (NEW!)</a></li> -->
+        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
+        <li><a href="{{ '/' | relative_url }}#themes">Themes</a></li>
+        <li><a href="{{ '/' | relative_url }}#submission">Submission</a></li>
         <li><a href="{{ '/' | relative_url }}#organizers"> Organizers</a></li>
-        <li><a href="{{ '/' | relative_url }}#archive-dates-program">Archive: CHI 2025 Workshop</a></li>
+        <li><a href="{{ '/2025' | relative_url }}">Archive: CHI 2025 Workshop</a></li>
       </ul>
     </nav>
   </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
   <main>
     {{ content }}
     <!-- After content, include the organizers list -->
-    {% include organizers.html %}
+    <!-- {% include organizers.html %} -->
   </main>
   
   <footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,9 +16,9 @@
         <li><a href="{{ '/' | relative_url }}#news">News</a></li>
         <li><a href="{{ '/' | relative_url }}#about">About</a></li>
         <!-- <li><a href="{{ '/' | relative_url }}#papers">2025 Papers</a></li> -->
-        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
         <li><a href="{{ '/' | relative_url }}#themes">Themes</a></li>
-        <li><a href="{{ '/' | relative_url }}#submission">Submission</a></li>
+        <li><a href="{{ '/' | relative_url }}#submission">Workshop Submission</a></li>
+        <li><a href="{{ '/hci-special-issue' | relative_url }}">Special Issue CFP</a></li>
         <li><a href="{{ '/' | relative_url }}#organizers"> Organizers</a></li>
         <li><a href="{{ '/2025' | relative_url }}">Archive: CHI 2025 Workshop</a></li>
       </ul>

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ _Understanding, Protecting, and Augmenting Human Cognition with Generative AI �
 
 ## News {#news}
 
-- We're accepting submissions to our CHI 2026 workshop!
+- We're accepting [submissions](/workshop/#submission) to our CHI 2026 workshop!
 -  <a href="https://www.microsoft.com/en-us/research/publication/understanding-protecting-and-augmenting-human-cognition-with-generative-ai-a-synthesis-of-the-chi-2025-tools-for-thought-workshop/">2025 Workshop Synthesis</a>
 
 - <a href="{{ '/hci-special-issue' | relative_url }}">2026 Human Computer Interaction Journal Special Issue CFP</a>
@@ -33,115 +33,103 @@ GenAI radically widens the scope and capability of automation for work, learning
 
 How does GenAI change workflows and human cognition? What are opportunities and challenges for designing GenAI systems that protect and augment thinking? Which theories, perspectives, and methods are relevant? This workshop aims to develop a multidisciplinary community interested in exploring these questions to protect against the erosion, and fuel the augmentation, of human cognition using GenAI.
 
+This workshop is a follow-up to the CHI 2025 Tools for Thought workshop, which brought together 56 participants with 34 accepted submissions, culminating in a workshop synthesis and an HCI journal special issue on tools for thought. While last year's workshop focussed on mapping the field, this edition moves towards developing operational frameworks, principles, and tools.
+
 For more details, see our [workshop proposal]({{ '/assets/Tools_for_Thought_with_Generative_AI_2026_Proposal.pdf' | relative_url }}).
 
 Feel free to [join our Discord server](https://discord.gg/WtEzx43ZmD), where you can ask questions, or discuss the topics of this workshop.
 
+## Workshop Themes {#themes}
+
+We invite contributions to our three core themes addressing questions such as:
+
+1. **TfT Strategies: Design and Usage**
+
+    *How can GenAI be designed and applied as a tool for thought?*
+
+
+   - What are promising design strategies, including interface mechanisms, interaction designs, and design patterns that protect or augment human cognition?
+   - What are effective usage strategies where AI is used to help people think, learn, create, and work better, even in general-purpose tools like ChatGPT that are not specifically designed as TfT?
+   - How can we systematise specific examples into tangible, transferable strategies across domains and contexts?
+   - What are useful framings for the role of GenAI (e.g., AI as provocateur or facilitator) that inspire effective design and usage?
+   - Can we theoretically ground these strategies and provide empirical evidence for their effectiveness?
+
+2. **TfT Outcomes: Definition and Measurement**
+   
+    *What are the outcomes of tools for thought, and how do we measure them?*
+
+   - What counts as a "good" outcome for TfTs? How do we define desirable outcomes beyond task performance?
+   - How can we capture intermediary outcomes (e.g., artefacts like notes or diagrams that scaffold thinking)?
+   - How do we measure cognitive outcomes such as understanding, learning, critical thinking, and metacognitive engagement?
+   - What role do task outcomes (performance) play, and how do we balance them with cognitive goals?
+   - What evaluation methods are appropriate for capturing the richness of cognition—including process tracing, artefact analysis, cognitive assessments, and longitudinal studies?
+   - How can we account for context-dependent and qualitative dimensions of cognitive change?
+
+3. **TfT Experience and Adoption**
+
+    *How can tools for thought achieve successful adoption and integration into people's workflows?*
+
+    - What makes a good experience in a TfT, and how is it adequately balanced with the friction that might be required to support cognitive engagement?
+    - How might we imbue users with intrinsic motivation to use GenAI in ways that support improved cognitive outcomes?
+    - What strategies can we employ to communicate the value of TfT to stakeholders and achieve buy-in at the organisational level?
+    - How might we manage trade-offs between productivity and cognitive outcomes to maximise successful integration and sustained use?
+    - Are there strategies that resolve the conflict between productivity and cognitive outcomes, allowing users to achieve both?
+
+## What to Submit {#submission}
+
+Your submission should address **at least one of the three themes** above.
+
+A workshop submission consists of:
+1. **Workshop paper**: Up to **4 pages (excluding references)** using the **2-column ACM format**
+2. **Miro board "mini poster"**: A filled-out Miro board template based on your contribution
+
+We encourage drawing from and building upon existing theories where possible—such as from cognitive, behavioural, and educational/learning sciences.
+
+Submissions can take diverse forms, including but not limited to:
+
+- Novel design concepts or prototypes
+- Empirical studies and evaluations
+- Theoretical frameworks and design principles
+- Usage strategies and case studies
+- Measurement techniques and methodologies
+- Critical reflections and provocations
+
+We generally encourage contributions that are oriented towards operationalisation, meaning that they provide clear paths to implementation and use - be it for a study design, evaluation approach, or TfT interface design - and/or that they are targeted at existing AI tools/uses and in which ways they are (or are not) a TfT.
+
+
+## How to Submit
+
+**Submission portal:** TBD
+
+**Submission Requirements:**
+
+1. **Workshop paper**: Upload your workshop paper as a PDF via the submission form
+2. **"Mini poster"**: 
+   - Make a copy of the [Miro board template]() in your own account
+   - Fill out the template
+   - Share your Miro board and copy the sharing link into the [submission form](/workshop/submission-form) ([Instructions]())
+3. **Number of attendees**: Provide number of authors hoping to attend
+
+**Tip**: Filling out the mini poster template **before or during** the process of writing the workshop paper may help you structure the latter and already include some of the components of the poster - but this is of course completely up to you.
+We do not expect you to fill out every box/field on the Miro board. Although we have tested the board with a range of contribution types, we are aware that not all the boxes might be equally applicable to all contributions.
+
+**Please note**: Accepted papers will be published on the workshop website. At least one author of each accepted submission must attend the workshop (and at most two authors may attend).
+
+## What Happens After Acceptance
+The organisers will thematically cluster the Miro board mini posters to form participant groups for collaborative work during the workshop. Before the workshop, participants will be asked to read the submissions (especially the mini posters) of their group members to enable focused and productive discussions.
+
+
+## Important Information
+
+**Submission deadline**: Thursday, February 5, 2026 AoE
+
+**Notification of acceptance**: Thursday, February 26, 2026 AoE
+
+**Camera-ready**: Thursday, March 26, 2026 AoE
+
+**Questions?** Contact us at [ADD EMAIL]
 
 ## Organizers {#organizers}
 
 {% include organizers2026.html %}
-
-## Archive: CHI 2025 Workshop {#archive-dates-program}
-
-## CHI 2025 Workshop Papers {#papers}
-
-All accepted papers for this workshop are available in our [GitHub repository](https://github.com/ai-tools-for-thought/workshop/tree/main/documents). You can browse and download the PDF files directly from there.
-
-| Author | Title |
-| --- | --- |
-| Dinesh Ayyappan and David A. Joyner | [Understanding, Protecting, and Augmenting Human Cognition with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Ayyappan%20and%20Joyner%20-%20CHI_ToolsForThought_PositionPaper_CameraReady.pdf) | 
-| Jessica Y. Bo et al. | [Who's the Leader? Analyzing Novice Workflows in LLM-Assisted Debugging of Machine Learning Code](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Bo%20et%20al%20-%20whos_the_leader_tools_for_thought_CHI25_.pdf)|
-| Chance Casteñeda and Jessica Mindel et al. | [Supporting AI-Augmented Meta-Decision Making with InDecision](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Castaneda%20and%20Mindel%20et%20al%20-%20CHI%20T4T%20-%20Supporting%20AI-Augmented%20Meta-Decision%20Making%20with%20InDecision.pdf)  |
-| Manni Cheung | [From Answer Machines to Ignorant Co-Learners: Designing AI to Augment Rather than Replace Human Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Cheung%20-%20From_Answering_Machines_to_Ignorant_Co_Learners__Final_.pdf) |
-| Peter Dalsgaard | [Generative AI as a Tool for Designerly Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Dalsgaard%20-%202025%20-%20Generative_AI_as_a_Tool_for_Designerly_Thinking.pdf) |
-| Yue (Chris) Fu and Alexis Hiniker | [Supporting Students' Reading and Cognition with AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Fu%20and%20Hiniker%20-%2025_CHI_Workshop__Students__Reading_and_Cognition%20-%20%20to%20Committee.pdf) |
-| Frederic Gmeiner et al. | [Designing Metacognitive Support Interactions to Augment People's Thinking in Complex (Co-)Creative Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Gmeiner%20et%20al%20-%20Gmeiner_DesigningMetacognitiveSupport_ToolsForThought_CHI25_CameraReady.pdf) |
-| Joshua Holstein et al. | [From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Holstein%20et%20al%20-%20CHI25_Tools_for_Thought_Consumption%20to%20Engagement%20Framework.pdf) |
-| Janet G. Johnson and Steven R. Rick | [The Promise and Peril of Collaboration: Fostering Appropriate Reliance When Problem-Solving with GenAI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Johnson%20and%20Rick%20-%20Toolsforthought_CHI25_CollaborativeGenAI.pdf) |
-| Anjali Khurana and Parmit K. Chilana | [Designing Semi-Automated Copilots: Balancing User Control and Guidance for Effective Human-Agent Collaboration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Khurana%20and%20Chilana%20-%20CHI2025_Workshop_CameraReady.pdf) |
-| Eunhye Kim et al. | [Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Kim%20et%20al%20-%20CHI25_Workshop_BeyondTools_Kim_CameraReady.pdf.pdf) |
-| Markus Langer | [Why Should we Invest Epistemic Labor in a World of Generative AI?](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Langer%20-%20CHI25_Tools_for_Thought_Workshop.pdf) |
-| Joanne Leong | [Designing Transformative Lenses to Aid Thinking](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Leong%20-%20JoanneLeong-TransformativeLenses-CameraReady.pdf) |
-| Can Liu and Wengxi Li | [Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20-%20Liu_Li_TFTWorkshop.pdf) |
-| Xingyu Bruce Liu et al. | [Interacting with Thoughtful AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Liu%20et%20al%20-%20CHI_2025_Workshop_Thought_Position_Paper.pdf) |
-| Bryan Min and Haijun Xia | [Feedforward in Generative AI: Opportunities for a Design Space](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Min%20and%20Xia%20-%20CHI25_Workshop___Feedforward_in_GenAI.pdf) |
-| Anirban Mukhopadhyay and Kurt Luther | [Tailoring Generative AI to Augment Creative Leadership in Capture-The-Flag Development](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Mukhopadhyay%20and%20Luther%20-%20Anirban_Tools_For_Thought_Workshop_Paper.pdf) |
-| Syeda Masooma Naqvi et al. | [Computational Reification of Creativity: How Generative AI Reshapes Creative Cognition](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Naqvi%20et%20al%20-%20CHI2025_Workshop_Tools4Thought.pdf) |
-| Sachita Nishal et al. | [Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Nishal%20et%20al%20-%20Tools%20for%20Thought%20-%20Camera-Ready.pdf) |
-| Kris Pilcher and Esen K. Tütüncü | [Purposefully Induced Psychosis (PIP): Embracing Hallucination as Imagination in Large Language Models](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Pilcher%20and%20Tutuncu%20-%20PIP_CHI25_TfTSubmission.pdf) |
-| James Prather and Brent N. Reeves | [Pedagogy for critical engagement with Generative AI](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Prather%20and%20Reeves%20-%20CHI_2025___Workshop_for_Tools_on_Thought.pdf) |
-| Chris Quintana and Rebecca M. Quintana | [Students' Experiences Using Generative AI Within Learning Experience Design Workflows](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Quintana%20and%20Quintana-CHI%202025_Workshop-FINAL.pdf) |
-| Kathrin Schnizer and Sven Mayer | [User-Centered AI for Data Exploration – Rethinking GenAI's Role in Visualization](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Schnizer%20and%20Mayer%20-%20schnizer2025usr.pdf) |
-| Anjali Singh et al. | [Protecting Human Cognition in the Age of AI](https://github.com/ai-tools-for-thought/workshop/tree/main/documents) |
-| Alexa Siu and Raymond Fok | [Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Singh%20et%20al%20-%20Tools_for_Thought_Workshop_paper.pdf) |
-| Petr Slovak | [Tools for (Changing) Thought: Scaffolding Cognitive Skills Development within Mental Health Contexts](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Slovak%20-%20Tools4Thought_workshop-cameraReady.pdf) |
-| Sangho Suh | [The Next Leap Forward in Human Intelligence: Expanding & Exploring Complex Spaces of Thought](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Suh%20-%20CHI25%20Tools%20for%20Thought%20Workshop%20-%20SanghoSuh.pdf) |
-| Nick von Felten | [Beyond Isolation: Towards an Interactionist Perspective on Human Bias and AI Bias](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Von%20Felten%20-%20Beyond_Isolation_Tools_For_Thought_CHI2025_Workshop.pdf) |
-| Sitong Wang and Lydia B. Chilton | [Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Wang%20and%20Chilton%20-%20Schemex.pdf) |
-| Haijun Xia | [Generative, Malleable, and Personal Information Environment](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Xia%20-%20Generative%2C%20Malleable%2C%20and%20Personal%20User%20Interfaces.%20Haijun%20Xia.%20UCSD.pdf) |
-| Yaqing Yang et al. | [From Overload to Insight: Scaffolding Creative Ideation through Structuring Inspiration](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yang%20et%20al%20-%20Scaffolding%20Creative%20Ideation.pdf) |
-| Ryan Yen et al. | [Something In Between Formal Spec and Informal Representation](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Yen%20et%20al%20-%20Semi_Formal_Programming__CHI25_T4T_Workshop_%20(3).pdf) |
-| Zelun Tony Zhang and Leon Reicherts | [Augmenting Human Cognition With Generative AI: Lessons From AI-Assisted Decision-Making](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zhang%20and%20Reicherts%20-%20T4T_Workshop_Paper_camera_ready.pdf) |
-| Tim Zindulka et al. | [Prompting by Doing: How Direct Manipulation can Protect and Augment Writers' Thoughts in AI Tools](https://github.com/ai-tools-for-thought/workshop/blob/main/documents/Zindulka%20et%20al%20-%20CHI25___Tools_for_Thoughts__Prompting_by_Doing.pdf) |
-
-### CHI 2025 Workshop Key Dates
-
-- **Deadline for submissions:** <del>Thursday, February 20 2025 AoE (extended)</del>
-- **Notifications of acceptance:** <del>Friday, February 28 2025</del> Monday, March 10, 2025 AoE (extended)</del>
-- **Camera-ready:** <del>Friday, April 11 2025 AoE</del>
-- **Day of Workshop:** <del>Saturday, April 26 2025 JST</del>
-
-### CHI 2025 Workshop Program
-
-**9:00–9:30 (30min)**  
-Welcome and introduction
-
-**9:30–10:45 (75min)**  
-The impact of GenAI on cognition and workflows (lightning talks + panel discussion)  
-- *Generative AI as a Tool for Designerly Thinking (Peter Dalsgaard)*  
-- *Protecting Human Cognition in the Age of AI (Anjali Singh)*
-- *From Consumption to Collaboration: Measuring Interaction Patterns to Augment Human Cognition in Open-Ended Tasks (Joshua Holstein)*  
-- *Beyond Tools: Understanding How Heavy Users Integrate LLMs into Everyday Tasks and Decision-Making (Eunhye Kim)*
-- *Supporting Students’ Reading and Cognition with AI (Chris Fu)*
-
-**10:45–11:10 (25min)**   
-Coffee break (and optional informal demos)  
-
-**11:10–12:40 (90min)**  
-Designing for cognitive protection and augmentation: User research (lightning talks + panel discussion)
-- *Augmenting Expert Cognition in the Age of Generative AI: Insights from Document-Centric Knowledge Work (Alexa Siu)*  
-- *Designing for Agency in LLM-Infused Writing Support Tools for Science Journalism (Sachita Nishal)*
-- *User-Centered AI for Data Exploration – Rethinking GenAI’s Role in Visualization (Kathrin Schnizer)*
-
-Designing for cognitive protection and augmentation: Systems (lightning talks + panel discussion)
-- *Schemex: Discovering Design Patterns from Examples through Iterative Abstraction and Refinement (Sitong Wang)*  
-- *Supporting AI-Augmented Meta-Decision Making with InDecision (Jessica Mindel)*  
-- *From Overload to Insight: Structuring Creative Ideation through Structuring Inspiration (Yaqing Yang)*
-
-**12:40–14:10 (90min)**  
-Lunch  
-
-**14:10–15:25 (75min)**  
-Designing for cognitive protection and augmentation: Design approaches (lightning talks + panel discussion)
-- *Prompting by Doing: How Direct Manipulation can Protect and Augment Writers’ Thoughts in AI Tools (Tim Zindulka)*  
-- *Feedforward in Generative AI: Opportunities for a Design Space (Bryan Min)*  
-- *Bridging the Cognitive Gap: Cross-Modality Perception in AI-Generated Content (Can Liu)*  
-- *Interacting with Thoughtful AI (Xingyu Bruce Liu)*  
-- *Something In Between Formal Spec and Informal Representation (Ryan Yen)*
-
-**15:40–16:05 (25min)**  
-Coffee break (and optional informal demos)  
-
-**16:05–17:20 (75min)**    
-Co-ideation session: Mapping research and design opportunities
-
-**17:20–17:50 (30min)**    
-Next steps and closing
-
-<br>
-
-Note that the workshop will be **in-person only** to facilitate in-depth discussion among all participants, and to avoid challenges in ensuring equitable opportunities for participation between in-person and remote attendees. While we acknowledge that this decision would unfortunately exclude those who cannot travel to attend in person, we believe that this trade-off would result in a superior experience for those who do attend, and is better aligned with the primary community-building aim of the workshop. Alongside synchronous in-person engagement, we will use [our Discord server](https://discord.gg/WtEzx43ZmD), which anyone is free to join, for asynchronous discussions before, during, and after the workshop.
-
-## CHI2025 Organizers
 

--- a/index.md
+++ b/index.md
@@ -103,20 +103,42 @@ We generally encourage contributions that are oriented towards operationalisatio
 
 **Submission Requirements:**
 
-1. **Workshop paper**: Upload your workshop paper as a PDF via the submission form
+1. **Workshop paper**: 
+   - Prepare your article according to the ACM article template with 'sigconf' style (\documentclass\[sigconf,screen\] {acmart}), or ACM primary article template if using Microsoft Word (Word template instructions). For details, see: [https://www.acm.org/publications/authors/submissions](https://www.acm.org/publications/authors/submissions)
+   - Upload the PDF and the source files of your workshop paper (LaTeX source or Word document) via the submission form.
+ 
 2. **"Mini poster"**: 
-   - Make a copy of the [Miro board template]() in your own account
-   - Fill out the template
-   - Share your Miro board and copy the sharing link into the [submission form](/workshop/submission-form) ([Instructions]())
-3. **Number of attendees**: Provide number of authors hoping to attend
+   - Make a copy of the [Miro board template](https://miro.com/app/board/uXjVGayRUc8=/?share_link_id=91990937828) in your own Miro account.
+    
+        Tip: You can find some sample “mini posters” here to give you an idea on how to fill out the mini poster template.
+   
+   - Fill out the template.
+   - Include the sharing URL to your Miro board and a PDF export of it in the submission form. Please follow the instructions in the Miro board for how to do this.
+ 
+3. **Number of attendees**: Provide the number of authors planning to attend (min.1 and max. 2).
+4. **Personal statement**: Prepare a max. 150-word personal statement for the attending author(s).
+
+
 
 **Tip**: Filling out the mini poster template **before or during** the process of writing the workshop paper may help you structure the latter and already include some of the components of the poster - but this is of course completely up to you.
 We do not expect you to fill out every box/field on the Miro board. Although we have tested the board with a range of contribution types, we are aware that not all the boxes might be equally applicable to all contributions.
 
 **Please note**: Accepted papers will be published on the workshop website. At least one author of each accepted submission must attend the workshop (and at most two authors may attend).
 
+**Submission**: [Click here](https://forms.fillout.com/t/u5Dx2rkszPus) to proceed to the submission form
+
 ## What Happens After Acceptance
 The organisers will thematically cluster the Miro board mini posters to form participant groups for collaborative work during the workshop. Before the workshop, participants will be asked to read the submissions (especially the mini posters) of their group members to enable focused and productive discussions.
+
+## Workshop Format
+This will be a 180-minute workshop organised around small group work:
+
+1. **Quick pitches**: Groups among themselves present each other’s Miro board to kick-off the conversation
+2. **Collaborative work**: Groups will work on tangible outputs of their choice (e.g., new frameworks, design principles, measurement techniques, theory development, or even low-fidelity TfT prototypes in a mini-hackathon style)
+3. **Group pitches**: Each group will present their results to all participants
+
+We aim for **45 participants** to foster rich discussion and meaningful collaboration.
+
 
 
 ## Important Information
@@ -127,7 +149,7 @@ The organisers will thematically cluster the Miro board mini posters to form par
 
 **Camera-ready**: Thursday, March 26, 2026 AoE
 
-**Questions?** Contact us at [ADD EMAIL]
+**Questions?** Contact us at [chi.tft.workshop@gmail.com](mailto:chi.tft.workshop@gmail.com)
 
 ## Organizers {#organizers}
 

--- a/submission-form.md
+++ b/submission-form.md
@@ -1,0 +1,39 @@
+---
+layout: article
+title: "Submission Form"
+---
+
+<h1 id="home">Submission Form<br></h1>
+
+**Corresponding author:**
+- First name(s): [Text input field]
+- Last name: [Text input field]
+- Email: [Text input field]
+- Institution: [Text input field]
+
+**Short personal statement from each author attending the workshop: [Multi-line text input field]**
+Statements should focus on relevant background, motivations, and interests for the workshop (max 150 words per statement).
+
+**Submission title:** [Text input field]
+**Submission keywords (separated by commas):** [Text input field]
+
+**PDF of your paper:** [File upload]
+**Overleaf source file or Word document of your paper:** [File upload]
+
+*according to the ACM article template with 'sigconf' style (\documentclass[sigconf,screen] {acmart}), or ACM primary article template if using Microsoft Word (Word template instructions) - for details, see links below:
+LaTeX: https://authors.acm.org/proceedings/production-information/preparing=your-article-
+with-latex
+Word: https://authors.acm.org/proceedings/production-information/preparing-your-article-
+with-microsoft-word *
+
+Link to instructions for creating a copy of the Miro board template [Add Link] and for creating the Miro board sharing link [Add Link].
+
+**Miro board sharing URL:** [Text input field]
+**PDF export of your Miro board:** [File upload]
+(This is just in case there should be any issues with accessing your Miro board via the link.)
+
+**How many paper authors you think would like to attend:** [Number input]
+Please note that in case of high demand we may need to cap the number of who can attend the workshop to a maximum of two per paper (as we had to do last year).
+
+**Any other comments or notes (optional):** [Multi-line text input field]
+**Any accessibility requirements (optional):** [Multi-line text input field]


### PR DESCRIPTION
The webpage is updated:
1. The CfP is added. (I did not add the workshop format at this time as it does not really belong to CfP. We may add a more detailed version when the workshop is nearby. Let me know if you believe it should be added at this time)
2. Since the webpage is too long and 2025 information might be confusing, I moved all archived information to an individual page. Please let me know if you have any suggestion.

Remaining issues:
1. Many links are not available. At least, we should fill in the contact email asap before making it public.
2. Submission form is not ready. I suppose we should move it to Google Form or PCS? Now I only add a new page as a placeholder

Please help check the updated page and let me know if you have any suggestions! Thanks!